### PR TITLE
Fix Makefile for install paths with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ ifeq ($(UNAME),CYGWIN_NT-10.0)
 endif
 
 install:
-	cp -r vendor/ninja.$(PLATFORM) $(cur__bin)/ninja.exe
+	cp -r vendor/ninja.$(PLATFORM) "$(cur__bin)/ninja.exe"


### PR DESCRIPTION
This should fix the following error I got with my profile name "Manuel Hornung OSS" on Windows 10:
```
    cp -r vendor/ninja.win C:/Users/Manuel Hornung OSS/.esy/3_/s/esy_cross__s__ninja_build-1.8.2001-10971c1b/bin/ninja.exe
    cp: target 'OSS/.esy/3_/s/esy_cross__s__ninja_build-1.8.2001-10971c1b/bin/ninja.exe' is not a directory
```